### PR TITLE
Remediate kpi documentation authority audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 *.log
 CLAUDE.md
 AGENTS.md
+strict-audit

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 Part of the [ZaveStudios multi-tenant platform](https://github.com/zavestudios/zavestudios) - provides the infrastructure layer for hosting multiple tenant applications with isolated resources.
 
+**Repository Category:** `infrastructure` (canonical classification in [REPO_TAXONOMY.md](https://github.com/zavestudios/platform-docs/blob/main/_platform/REPO_TAXONOMY.md))
+
 ## Quick Start
 
 **First-time setup from laptop** (zero to running cluster in ~11 minutes):
+
+**Run manually by human:**
 
 ```bash
 # 1. Clone repository
@@ -160,6 +164,7 @@ For detailed architecture, see [docs/kpi-architecture.md](docs/kpi-architecture.
 ## Common Operations
 
 **Rebuild cluster (preserves base image):**
+**Run manually by human:**
 ```bash
 cd terraform-libvirt
 
@@ -179,6 +184,7 @@ kubectl get nodes
 ```
 
 **Update base image:**
+**Run manually by human:**
 ```bash
 # On hypervisor host (~3.5 minutes)
 cd ~/kubernetes-platform-infrastructure/packer/k3s-node
@@ -194,6 +200,7 @@ docker compose run --rm terraform apply
 ```
 
 **Access cluster:**
+**Run manually by human:**
 ```bash
 # RECOMMENDED: Via bastion host (production pattern)
 ssh k3s-bastion-01
@@ -238,11 +245,13 @@ sudo k3s kubectl get nodes
 After cluster is operational:
 
 1. **Verify bastion kubectl access** - Kubeconfig auto-configured during cloud-init
+   **Run manually by human:**
    ```bash
    ssh k3s-bastion-01 'kubectl get nodes'
    ```
 
 2. **Bootstrap Flux GitOps** - Platform services management
+   **Run manually by human:**
    ```bash
    # SSH to bastion
    ssh k3s-bastion-01
@@ -277,7 +286,7 @@ This infrastructure hosts multiple tenant applications:
 
 Each application has:
 - Isolated Kubernetes namespace
-- Dedicated database tenant in [pg-multitenant](https://github.com/zavestudios/pg-multitenant)
+- Dedicated database tenant in [pg](https://github.com/zavestudios/pg)
 - Deployment via ArgoCD GitOps
 
 ---


### PR DESCRIPTION
## Summary
- add explicit repository category declaration to README (`infrastructure`)
- label cluster command sections as **Run manually by human**
- correct PostgreSQL platform-service link to `zavestudios/pg`
- ignore local `strict-audit` artifact via `.gitignore`

## Why
Align repository documentation with infrastructure-layer authority contracts:
- local category clarity from taxonomy
- explicit human-run labeling for cluster mutation command flows
- link consistency with canonical repo taxonomy

## Validation
- category line present in README
- manual execution labels present around kubectl/bootstrap sections
- `strict-audit` no longer appears as untracked due to `.gitignore`
