### PR TITLE
Add shared PostgreSQL VM baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ k9s               # interactive cluster management
 
 - **3-node k3s cluster**: 1 control plane + 2 workers
 - **Bastion host**: Dedicated jump box with kubectl, k9s, flux, helm pre-installed
+- **Optional shared PostgreSQL VM**: Dedicated data-service host for tenant workloads
 - **Automated deployment**: Terraform + Packer + cloud-init
-- **Static networking**: Predictable IPs (192.168.122.10-13)
+- **Static networking**: Predictable IPs for cluster and shared service VMs
 - **Production patterns**: Bastion architecture, network isolation, proper TLS
 - **Reproducible**: Destroy and recreate identical cluster in ~5 minutes
 
@@ -113,11 +114,13 @@ The resulting outputs will be consumed later in `gitops` when wiring Vault to AW
 - Hypervisor: Virtualization host (192.168.1.x)
 - Bastion: Jump box with cluster tools (192.168.122.13)
 - Cluster: Isolated network (192.168.122.10-12)
+- Shared PostgreSQL VM: Optional external data-service host (192.168.122.20)
 - Access: Laptop → SSH → Bastion → Cluster
 
 **Node Specifications:**
 - Control Plane/Workers: 6 vCPUs, 10GB RAM, 80GB disk
 - Bastion: 2 vCPUs, 4GB RAM, 80GB disk (inherited from base volume)
+- Shared PostgreSQL VM: 4 vCPUs, 8GB RAM, 120GB disk (optional)
 - Ubuntu 24.04 LTS
 - k3s v1.34.3+k3s1 (pinned, with TLS SAN for 127.0.0.1)
 
@@ -133,6 +136,7 @@ The resulting outputs will be consumed later in `gitops` when wiring Vault to AW
 - Terraform provisions VMs via libvirt provider
 - Terraform generates inter-VM SSH keypair for bastion → control plane communication
 - cloud-init installs k3s (cluster) or tools (bastion)
+- cloud-init can also provision an optional shared PostgreSQL VM outside the cluster
 - Bastion cloud-init automatically fetches kubeconfig from control plane during provisioning
 
 **Tools on Bastion:**

--- a/docs/kpi-architecture.md
+++ b/docs/kpi-architecture.md
@@ -23,6 +23,16 @@ kubernetes-platform-infrastructure (kpi) provides Infrastructure as Code to depl
 - Production-grade automation and patterns
 - AWS deployment capability maintained via Terraform
 
+### Shared Data Services
+
+The infrastructure layer may also provision dedicated data-service VMs outside the Kubernetes cluster.
+
+Current intended pattern:
+- shared PostgreSQL VM for tenant databases
+- shared Redis VM for tenant broker/cache workloads
+
+These VMs live on the same libvirt network as the cluster, but they remain outside Kubernetes reconciliation and outside the cluster failure domain.
+
 ---
 
 ## Cluster Architecture
@@ -54,6 +64,8 @@ Home/Office Network (192.168.1.0/24)
                 ├─ k3s-cp-01 (192.168.122.10) - static IP
                 ├─ k3s-worker-01 (192.168.122.11) - static IP
                 └─ k3s-worker-02 (192.168.122.12) - static IP
+                ├─ k3s-bastion-01 (192.168.122.13) - static IP
+                └─ pg-01 (192.168.122.20) - static IP, optional
 ```
 
 **Network configuration:**

--- a/terraform-libvirt/cloud-init/postgres.yml.tpl
+++ b/terraform-libvirt/cloud-init/postgres.yml.tpl
@@ -1,0 +1,64 @@
+#cloud-config
+datasource_list: [ NoCloud, None ]
+datasource:
+  NoCloud:
+    fs_label: cidata
+
+hostname: ${hostname}
+fqdn: ${hostname}.local
+
+users:
+  - name: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ${ssh_public_key}
+
+ssh_pwauth: true
+chpasswd:
+  expire: false
+  list:
+    - ubuntu:ubuntu
+
+timezone: UTC
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - curl
+  - vim
+  - htop
+  - net-tools
+  - jq
+  - postgresql
+  - postgresql-contrib
+
+write_files:
+  - path: /etc/motd
+    permissions: "0644"
+    content: |
+      Shared PostgreSQL host for tenant workloads.
+      This VM provides the platform-owned Postgres runtime only.
+      Tenant databases, roles, and grants are managed separately by the pg platform-service.
+
+runcmd:
+  - |
+    echo "Waiting for network..."
+    for i in {1..30}; do
+      if ip route | grep -q "default"; then
+        echo "Network ready"
+        break
+      fi
+      sleep 2
+    done
+
+    echo "Enabling PostgreSQL service..."
+    systemctl enable postgresql
+    systemctl restart postgresql
+    systemctl --no-pager --full status postgresql || true
+
+    echo "PostgreSQL VM baseline complete"
+
+final_message: "Shared PostgreSQL VM ${hostname} is ready after $UPTIME seconds"

--- a/terraform-libvirt/main.tf
+++ b/terraform-libvirt/main.tf
@@ -46,9 +46,9 @@ resource "libvirt_volume" "control_plane" {
 }
 
 resource "libvirt_cloudinit_disk" "control_plane" {
-  count     = var.control_plane_count
-  name      = "k3s-cp-${format("%02d", count.index + 1)}-cloudinit.iso"
-  pool      = var.libvirt_pool
+  count = var.control_plane_count
+  name  = "k3s-cp-${format("%02d", count.index + 1)}-cloudinit.iso"
+  pool  = var.libvirt_pool
   user_data = templatefile("${path.module}/cloud-init/k3s-cp.yml.tpl", {
     hostname            = "k3s-cp-${format("%02d", count.index + 1)}"
     ssh_public_key      = local.ssh_public_key
@@ -57,7 +57,7 @@ resource "libvirt_cloudinit_disk" "control_plane" {
     k3s_token           = local.k3s_token
     node_index          = count.index
   })
-  meta_data = <<-EOT
+  meta_data      = <<-EOT
     instance-id: k3s-cp-${format("%02d", count.index + 1)}-${uuid()}
     local-hostname: k3s-cp-${format("%02d", count.index + 1)}
   EOT
@@ -118,17 +118,17 @@ resource "libvirt_volume" "worker" {
 }
 
 resource "libvirt_cloudinit_disk" "worker" {
-  count     = var.worker_count
-  name      = "k3s-worker-${format("%02d", count.index + 1)}-cloudinit.iso"
-  pool      = var.libvirt_pool
+  count = var.worker_count
+  name  = "k3s-worker-${format("%02d", count.index + 1)}-cloudinit.iso"
+  pool  = var.libvirt_pool
   user_data = templatefile("${path.module}/cloud-init/k3s-worker.yml.tpl", {
     hostname         = "k3s-worker-${format("%02d", count.index + 1)}"
     ssh_public_key   = local.ssh_public_key
     k3s_version      = local.k3s_version
     k3s_token        = local.k3s_token
-    control_plane_ip = "192.168.122.10"  # Changed to static IP
+    control_plane_ip = "192.168.122.10" # Changed to static IP
   })
-  meta_data = <<-EOT
+  meta_data      = <<-EOT
     instance-id: k3s-worker-${format("%02d", count.index + 1)}-${uuid()}
     local-hostname: k3s-worker-${format("%02d", count.index + 1)}
   EOT
@@ -186,12 +186,12 @@ resource "libvirt_volume" "bastion" {
   pool           = var.libvirt_pool
   base_volume_id = libvirt_volume.base.id
   # Size inherited from base volume (80GB) - must be >= base volume size
-  format         = "qcow2"
+  format = "qcow2"
 }
 
 resource "libvirt_cloudinit_disk" "bastion" {
-  name      = "k3s-bastion-01-cloudinit.iso"
-  pool      = var.libvirt_pool
+  name = "k3s-bastion-01-cloudinit.iso"
+  pool = var.libvirt_pool
   user_data = templatefile("${path.module}/cloud-init/bastion.yml.tpl", {
     hostname             = "k3s-bastion-01"
     ssh_public_key       = local.ssh_public_key
@@ -200,7 +200,7 @@ resource "libvirt_cloudinit_disk" "bastion" {
     k3s_version          = local.k3s_version
     control_plane_ip     = "192.168.122.10"
   })
-  meta_data = <<-EOT
+  meta_data      = <<-EOT
     instance-id: k3s-bastion-01-${uuid()}
     local-hostname: k3s-bastion-01
   EOT
@@ -249,4 +249,72 @@ resource "libvirt_domain" "bastion" {
   qemu_agent = false
 
   depends_on = [libvirt_domain.control_plane]
+}
+
+# Shared PostgreSQL VM
+resource "libvirt_volume" "postgres" {
+  count          = var.postgres_enabled ? 1 : 0
+  name           = "${var.postgres_hostname}.qcow2"
+  pool           = var.libvirt_pool
+  base_volume_id = libvirt_volume.base.id
+  size           = var.postgres_disk_size
+  format         = "qcow2"
+}
+
+resource "libvirt_cloudinit_disk" "postgres" {
+  count = var.postgres_enabled ? 1 : 0
+  name  = "${var.postgres_hostname}-cloudinit.iso"
+  pool  = var.libvirt_pool
+  user_data = templatefile("${path.module}/cloud-init/postgres.yml.tpl", {
+    hostname       = var.postgres_hostname
+    ssh_public_key = local.ssh_public_key
+  })
+  meta_data      = <<-EOT
+    instance-id: ${var.postgres_hostname}-${uuid()}
+    local-hostname: ${var.postgres_hostname}
+  EOT
+  network_config = <<-EOT
+    version: 2
+    ethernets:
+      ens3:
+        addresses:
+          - ${var.postgres_ip}/24
+        routes:
+          - to: default
+            via: 192.168.122.1
+        nameservers:
+          addresses: [8.8.8.8, 1.1.1.1]
+  EOT
+}
+
+resource "libvirt_domain" "postgres" {
+  count  = var.postgres_enabled ? 1 : 0
+  name   = var.postgres_hostname
+  memory = var.postgres_memory
+  vcpu   = var.postgres_vcpu
+
+  cloudinit = libvirt_cloudinit_disk.postgres[0].id
+
+  disk {
+    volume_id = libvirt_volume.postgres[0].id
+  }
+
+  network_interface {
+    network_name   = var.libvirt_network
+    wait_for_lease = false
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  graphics {
+    type        = "spice"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  qemu_agent = false
 }

--- a/terraform-libvirt/outputs.tf
+++ b/terraform-libvirt/outputs.tf
@@ -45,13 +45,20 @@ output "cluster_info" {
     control_plane_count = var.control_plane_count
     worker_count        = var.worker_count
     bastion_ip          = "192.168.122.13"
+    postgres_enabled    = var.postgres_enabled
+    postgres_ip         = var.postgres_enabled ? var.postgres_ip : null
     k3s_version         = local.k3s_version
-    total_vcpu          = (var.control_plane_count * var.control_plane_vcpu) + (var.worker_count * var.worker_vcpu) + var.bastion_vcpu
-    total_memory_gb     = ((var.control_plane_count * var.control_plane_memory) + (var.worker_count * var.worker_memory) + var.bastion_memory) / 1024
+    total_vcpu          = (var.control_plane_count * var.control_plane_vcpu) + (var.worker_count * var.worker_vcpu) + var.bastion_vcpu + (var.postgres_enabled ? var.postgres_vcpu : 0)
+    total_memory_gb     = ((var.control_plane_count * var.control_plane_memory) + (var.worker_count * var.worker_memory) + var.bastion_memory + (var.postgres_enabled ? var.postgres_memory : 0)) / 1024
   }
 }
 
 output "bastion_access" {
   description = "Bastion SSH access command"
   value       = "ssh ubuntu@192.168.122.13 (or via hypervisor: ssh kpi-bastion-01)"
+}
+
+output "postgres_access" {
+  description = "Shared PostgreSQL VM SSH access command"
+  value       = var.postgres_enabled ? "ssh ubuntu@${var.postgres_ip}" : null
 }

--- a/terraform-libvirt/terraform.tfvars.example
+++ b/terraform-libvirt/terraform.tfvars.example
@@ -23,6 +23,14 @@ control_plane_memory = 10240  # Memory in MB (10GB)
 worker_vcpu   = 6      # vCPUs per worker node
 worker_memory = 10240  # Memory in MB (10GB)
 
+# Optional Shared PostgreSQL VM
+# postgres_enabled   = true
+# postgres_hostname  = "pg-01"
+# postgres_ip        = "192.168.122.20"
+# postgres_vcpu      = 4      # vCPUs
+# postgres_memory    = 8192   # Memory in MB (8GB)
+# postgres_disk_size = 128849018880  # 120GB
+
 # Disk Size (in bytes)
 disk_size = 85899345920  # 80GB
 

--- a/terraform-libvirt/variables.tf
+++ b/terraform-libvirt/variables.tf
@@ -94,3 +94,39 @@ variable "bastion_memory" {
   type        = number
   default     = 4096
 }
+
+variable "postgres_enabled" {
+  description = "Whether to provision the shared PostgreSQL VM"
+  type        = bool
+  default     = false
+}
+
+variable "postgres_hostname" {
+  description = "Hostname for the shared PostgreSQL VM"
+  type        = string
+  default     = "pg-01"
+}
+
+variable "postgres_ip" {
+  description = "Static IP address for the shared PostgreSQL VM"
+  type        = string
+  default     = "192.168.122.20"
+}
+
+variable "postgres_vcpu" {
+  description = "Number of vCPUs for the shared PostgreSQL VM"
+  type        = number
+  default     = 4
+}
+
+variable "postgres_memory" {
+  description = "Memory in MB for the shared PostgreSQL VM"
+  type        = number
+  default     = 8192
+}
+
+variable "postgres_disk_size" {
+  description = "Disk size in bytes for the shared PostgreSQL VM (default 120GB)"
+  type        = number
+  default     = 128849018880
+}

--- a/terraform-libvirt/versions.tf
+++ b/terraform-libvirt/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.6.0"
-  
+
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"


### PR DESCRIPTION
## Summary
- add an optional shared PostgreSQL VM to the existing `terraform-libvirt` surface
- give the VM its own static IP, sizing knobs, output surface, and cloud-init baseline
- document the new external data-service pattern in the repo docs

## Testing
- `docker compose -f terraform-libvirt/docker-compose.yml run --rm terraform fmt`
- `docker compose -f terraform-libvirt/docker-compose.yml run --rm terraform fmt -check`

## Notes
- the new VM is disabled by default via `postgres_enabled = false`
- this PR only establishes the host baseline and handoff surface for `pg`; it does not provision tenant databases or roles

Closes #45
