### PR TITLE
fix(kpi): enable autostart for shared service vms

### DIFF
--- a/terraform-libvirt/main.tf
+++ b/terraform-libvirt/main.tf
@@ -293,6 +293,7 @@ resource "libvirt_domain" "postgres" {
   name   = var.postgres_hostname
   memory = var.postgres_memory
   vcpu   = var.postgres_vcpu
+  autostart = true
 
   cloudinit = libvirt_cloudinit_disk.postgres[0].id
 
@@ -362,6 +363,7 @@ resource "libvirt_domain" "redis" {
   name   = var.redis_hostname
   memory = var.redis_memory
   vcpu   = var.redis_vcpu
+  autostart = true
 
   cloudinit = libvirt_cloudinit_disk.redis[0].id
 

--- a/terraform-libvirt/terraform.tfvars.example
+++ b/terraform-libvirt/terraform.tfvars.example
@@ -37,7 +37,7 @@ worker_memory = 10240  # Memory in MB (10GB)
 # redis_ip        = "192.168.122.21"
 # redis_vcpu      = 2      # vCPUs
 # redis_memory    = 4096   # Memory in MB (4GB)
-# redis_disk_size = 42949672960  # 40GB
+# redis_disk_size = 85899345920  # 80GB
 
 # Disk Size (in bytes)
 disk_size = 85899345920  # 80GB

--- a/terraform-libvirt/variables.tf
+++ b/terraform-libvirt/variables.tf
@@ -162,7 +162,7 @@ variable "redis_memory" {
 }
 
 variable "redis_disk_size" {
-  description = "Disk size in bytes for the shared Redis VM (default 40GB)"
+  description = "Disk size in bytes for the shared Redis VM (default 80GB)"
   type        = number
-  default     = 42949672960
+  default     = 85899345920
 }


### PR DESCRIPTION
## Summary

This makes the shared service VMs start automatically on the libvirt host.

- set `autostart = true` on the PostgreSQL domain
- set `autostart = true` on the Redis domain

## Why

During Keycloak recovery, the shared PostgreSQL VM `pg-01` and Redis VM `redis-01` were found shut off while the k3s cluster VMs were running. Recovery required a targeted Terraform apply to start both VMs and enable autostart.

Encoding this in Terraform makes the shared service dependency explicit and avoids repeating the same break-glass recovery path after host reboot.
