### PR TITLE
feat(cloudflare): add Cloudflare Access protection for operator UIs

### DIFF
--- a/terraform-cloudflare/main.tf
+++ b/terraform-cloudflare/main.tf
@@ -122,3 +122,183 @@ resource "cloudflare_record" "policyreporter_on_prem" {
   proxied = true
   comment = "Policy Reporter via Cloudflare Tunnel (on-prem)"
 }
+
+# Cloudflare Access Application for Operator UIs
+resource "cloudflare_zero_trust_access_application" "operator_uis" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Platform Operator UIs"
+  domain                    = "vault-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+# Additional domains for the Access Application
+resource "cloudflare_zero_trust_access_application" "argocd" {
+  account_id                = var.cloudflare_account_id
+  name                      = "ArgoCD"
+  domain                    = "argocd-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_application" "grafana" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Grafana"
+  domain                    = "grafana-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_application" "prometheus" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Prometheus"
+  domain                    = "prometheus-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_application" "alertmanager" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Alertmanager"
+  domain                    = "alertmanager-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_application" "loki" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Loki"
+  domain                    = "loki-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_application" "kiali" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Kiali"
+  domain                    = "kiali-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_application" "policyreporter" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Policy Reporter"
+  domain                    = "policyreporter-on-prem.zavestudios.com"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+}
+
+# Access Policy for Operator UIs - Vault
+resource "cloudflare_zero_trust_access_policy" "operator_uis_policy" {
+  application_id = cloudflare_zero_trust_access_application.operator_uis.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}
+
+# Access Policy for ArgoCD
+resource "cloudflare_zero_trust_access_policy" "argocd_policy" {
+  application_id = cloudflare_zero_trust_access_application.argocd.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}
+
+# Access Policy for Grafana
+# NOTE: Grafana has a reusable policy created during onboarding that cannot be easily managed via Terraform
+# Manage this policy manually in the Cloudflare UI for now
+# resource "cloudflare_zero_trust_access_policy" "grafana_policy" {
+#   application_id = cloudflare_zero_trust_access_application.grafana.id
+#   account_id     = var.cloudflare_account_id
+#   name           = "Allow Operators"
+#   precedence     = 1
+#   decision       = "allow"
+#
+#   include {
+#     email = var.operator_emails
+#   }
+# }
+
+# Access Policy for Prometheus
+resource "cloudflare_zero_trust_access_policy" "prometheus_policy" {
+  application_id = cloudflare_zero_trust_access_application.prometheus.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}
+
+# Access Policy for Alertmanager
+resource "cloudflare_zero_trust_access_policy" "alertmanager_policy" {
+  application_id = cloudflare_zero_trust_access_application.alertmanager.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}
+
+# Access Policy for Loki
+resource "cloudflare_zero_trust_access_policy" "loki_policy" {
+  application_id = cloudflare_zero_trust_access_application.loki.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}
+
+# Access Policy for Kiali
+resource "cloudflare_zero_trust_access_policy" "kiali_policy" {
+  application_id = cloudflare_zero_trust_access_application.kiali.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}
+
+# Access Policy for Policy Reporter
+resource "cloudflare_zero_trust_access_policy" "policyreporter_policy" {
+  application_id = cloudflare_zero_trust_access_application.policyreporter.id
+  account_id     = var.cloudflare_account_id
+  name           = "Allow Operators"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.operator_emails
+  }
+}

--- a/terraform-cloudflare/terraform.tfvars.example
+++ b/terraform-cloudflare/terraform.tfvars.example
@@ -1,4 +1,5 @@
 cloudflare_api_token  = "your-cloudflare-api-token-here"
 cloudflare_account_id = "your-cloudflare-account-id"
-cloudflare_zone_id    = "your-zone-id-for-zavestudios-com"
-tunnel_name           = "zavestudios-on-prem"
+cloudflare_zone_id    = "your-zone-id-"
+tunnel_name           = "your-tunnel-name"
+operator_emails       = ["operator@example.com"]

--- a/terraform-cloudflare/variables.tf
+++ b/terraform-cloudflare/variables.tf
@@ -19,3 +19,8 @@ variable "tunnel_name" {
   type        = string
   default     = "zavestudios-on-prem"
 }
+
+variable "operator_emails" {
+  description = "List of email addresses allowed to access operator UIs via Cloudflare Access"
+  type        = list(string)
+}


### PR DESCRIPTION
  Add edge authentication layer for all platform operator/admin surfaces.

  Changes:
  - Add 8 Cloudflare Access applications for operator UIs
  - Add Access policies restricting access to authorized operator emails
  - Update to non-deprecated cloudflare_zero_trust_access_* resources
  - Add operator_emails variable for policy configuration
  - Grafana policy managed manually (reusable policy from onboarding)

  Protected services:
  - vault-on-prem, argocd-on-prem, grafana-on-prem
  - prometheus-on-prem, alertmanager-on-prem, loki-on-prem
  - kiali-on-prem, policyreporter-on-prem

  Public services (intentionally no Access):
  - sso-on-prem (Keycloak IdP for OIDC)
  - panchito-on-prem (public application)

  Defense-in-depth: Cloudflare Access (edge) + application auth (layer 2).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>