### PR TITLE
feat: Vault policy IaC (terraform-vault module)

### DIFF
--- a/terraform-vault/main.tf
+++ b/terraform-vault/main.tf
@@ -1,0 +1,108 @@
+# ---------------------------------------------------------------------------
+# Platform policy
+# Covers shared platform secrets consumed by ESO across all namespaces.
+# ---------------------------------------------------------------------------
+resource "vault_policy" "platform" {
+  name = "platform"
+
+  policy = <<-EOT
+    path "secret/data/platform/*" {
+      capabilities = ["read"]
+    }
+    path "secret/metadata/platform/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+# ---------------------------------------------------------------------------
+# Tenant policies
+# One policy per tenant; grants read access to that tenant's KV subtree only.
+# Add a new block when onboarding a new tenant.
+# ---------------------------------------------------------------------------
+resource "vault_policy" "listings_ingest" {
+  name = "listings-ingest"
+
+  policy = <<-EOT
+    path "secret/data/tenants/listings-ingest/*" {
+      capabilities = ["read"]
+    }
+    path "secret/metadata/tenants/listings-ingest/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_policy" "mia" {
+  name = "mia"
+
+  policy = <<-EOT
+    path "secret/data/tenants/mia/*" {
+      capabilities = ["read"]
+    }
+    path "secret/metadata/tenants/mia/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_policy" "oracle" {
+  name = "oracle"
+
+  policy = <<-EOT
+    path "secret/data/tenants/oracle/*" {
+      capabilities = ["read"]
+    }
+    path "secret/metadata/tenants/oracle/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_policy" "panchito" {
+  name = "panchito"
+
+  policy = <<-EOT
+    path "secret/data/tenants/panchito/*" {
+      capabilities = ["read"]
+    }
+    path "secret/metadata/tenants/panchito/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_policy" "rigoberta" {
+  name = "rigoberta"
+
+  policy = <<-EOT
+    path "secret/data/tenants/rigoberta/*" {
+      capabilities = ["read"]
+    }
+    path "secret/metadata/tenants/rigoberta/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+# ---------------------------------------------------------------------------
+# Kubernetes auth role: external-secrets
+# Bound to the vault-reader service account used by the ClusterSecretStore.
+# All tenant and platform policies are attached here so ESO can read any
+# managed secret path from a single auth identity.
+# ---------------------------------------------------------------------------
+resource "vault_kubernetes_auth_backend_role" "external_secrets" {
+  backend                          = var.kubernetes_auth_mount
+  role_name                        = "external-secrets"
+  bound_service_account_names      = [var.vault_reader_service_account]
+  bound_service_account_namespaces = [var.vault_reader_namespace]
+  token_ttl                        = 3600
+  token_policies = [
+    vault_policy.platform.name,
+    vault_policy.listings_ingest.name,
+    vault_policy.mia.name,
+    vault_policy.oracle.name,
+    vault_policy.panchito.name,
+    vault_policy.rigoberta.name,
+  ]
+}

--- a/terraform-vault/outputs.tf
+++ b/terraform-vault/outputs.tf
@@ -1,0 +1,16 @@
+output "policy_names" {
+  description = "All Vault policy names managed by this module."
+  value = [
+    vault_policy.platform.name,
+    vault_policy.listings_ingest.name,
+    vault_policy.mia.name,
+    vault_policy.oracle.name,
+    vault_policy.panchito.name,
+    vault_policy.rigoberta.name,
+  ]
+}
+
+output "external_secrets_role" {
+  description = "Name of the Kubernetes auth role used by ESO."
+  value       = vault_kubernetes_auth_backend_role.external_secrets.role_name
+}

--- a/terraform-vault/providers.tf
+++ b/terraform-vault/providers.tf
@@ -1,0 +1,4 @@
+provider "vault" {
+  address = var.vault_address
+  token   = var.vault_token
+}

--- a/terraform-vault/terraform.tfvars.example
+++ b/terraform-vault/terraform.tfvars.example
@@ -1,0 +1,24 @@
+# Copy to terraform.tfvars and fill in values before running.
+
+vault_address  = "https://vault-on-prem.zavestudios.com"
+vault_token    = "hvs.REPLACE_WITH_OPERATOR_TOKEN"
+kubernetes_host = "https://REPLACE_WITH_K8S_API_HOST"
+
+# Defaults match the current platform configuration; override only if changed.
+# kubernetes_auth_mount        = "kubernetes"
+# vault_reader_service_account = "vault-reader"
+# vault_reader_namespace       = "platform"
+
+# ---------------------------------------------------------------------------
+# Importing existing Vault state
+# Run these import commands once before the first plan/apply.
+# Exact policy names must match whatever is currently in Vault.
+# ---------------------------------------------------------------------------
+#
+# terraform import vault_policy.platform platform
+# terraform import vault_policy.listings_ingest listings-ingest
+# terraform import vault_policy.mia mia
+# terraform import vault_policy.oracle oracle
+# terraform import vault_policy.panchito panchito
+# terraform import vault_policy.rigoberta rigoberta
+# terraform import vault_kubernetes_auth_backend_role.external_secrets kubernetes/role/external-secrets

--- a/terraform-vault/variables.tf
+++ b/terraform-vault/variables.tf
@@ -1,0 +1,33 @@
+variable "vault_address" {
+  description = "Vault server address."
+  type        = string
+}
+
+variable "vault_token" {
+  description = "Vault root or operator token with policy and auth management capabilities."
+  type        = string
+  sensitive   = true
+}
+
+variable "kubernetes_host" {
+  description = "Kubernetes API server address for the external-secrets auth role."
+  type        = string
+}
+
+variable "kubernetes_auth_mount" {
+  description = "Mount path for the Kubernetes auth backend."
+  type        = string
+  default     = "kubernetes"
+}
+
+variable "vault_reader_service_account" {
+  description = "Service account used by ESO to authenticate with Vault."
+  type        = string
+  default     = "vault-reader"
+}
+
+variable "vault_reader_namespace" {
+  description = "Namespace containing the ESO service account."
+  type        = string
+  default     = "platform"
+}

--- a/terraform-vault/versions.tf
+++ b/terraform-vault/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `terraform-vault/` module following the same flat layout as `terraform-cloudflare/` and `terraform-aws-vault-auto-unseal/`
- One `vault_policy` per tenant — each grants read-only access to that tenant's KV subtree (`secret/data/tenants/<name>/*`)
- One platform policy covering `secret/data/platform/*` (Cloudflare, GHCR, MinIO, Airflow, Keycloak secrets)
- One `vault_kubernetes_auth_backend_role` (`external-secrets`) binding all policies to the `vault-reader` service account in the `platform` namespace — mirrors the current ClusterSecretStore configuration
- `terraform.tfvars.example` includes the full set of `terraform import` commands needed to bootstrap against existing Vault state

## Policy inventory derived from

All ExternalSecret `remoteRef.key` values across the gitops repo were enumerated to confirm coverage before writing policies. Paths covered:

- `platform/cloudflare`, `platform/ghcr`, `platform/minio/root`
- `platform/services/airflow/*`, `platform/services/keycloak/*`
- `tenants/listings-ingest/*`, `tenants/mia/*`, `tenants/oracle/*`, `tenants/panchito/*`, `tenants/rigoberta/*`

## First-run steps (operator)

```
cp terraform.tfvars.example terraform.tfvars
# fill in vault_address, vault_token, kubernetes_host

# import existing Vault state (see tfvars.example for all commands)
terraform import vault_policy.platform platform
# ... remaining imports

terraform plan
terraform apply
```

## Adding a new tenant

Add one `vault_policy` block to `main.tf` and reference it in `vault_kubernetes_auth_backend_role.external_secrets.token_policies`. Submit as a PR.

## Related

- gitops#205 (this closes it)
- gitops#206 — MinIO storage for listings-ingest (adds `platform/minio/root` and `tenants/listings-ingest/storage` paths, both covered by policies in this module)